### PR TITLE
get description from share bookmarklet

### DIFF
--- a/templates/default/entity/IdnoPlugins/Reactions/Like/edit.tpl.php
+++ b/templates/default/entity/IdnoPlugins/Reactions/Like/edit.tpl.php
@@ -79,21 +79,16 @@ if ($type == 'like') {
      }
      if ($("#target").val() != '') {
          var url = $("#target").val(); 
-         if (url != '') {
-             $('#description-spinner').show();
-
-             var endpoint = "<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>reactions/fetch";
-             $.get(endpoint, {"url": url}, function success(result) {
-                 $('#description').val(result.description || '');
-                 $('#<?= $body_id ?>').val(result.content || '');
-                 $('#description-spinner').hide();
-                 $('#description-container').show();
-             });
+         getDescription(url);
          }
-      }
-
+    
      $('#target').change(function () {
          var url = $(this).val();
+         getDescription(url);
+     });
+ });
+
+function getDescription(url){
          if (url != '') {
              $('#description-spinner').show();
 
@@ -105,8 +100,7 @@ if ($type == 'like') {
                  $('#description-container').show();
              });
          }
-     });
- });
+    }
 
 
 </script>

--- a/templates/default/entity/IdnoPlugins/Reactions/Like/edit.tpl.php
+++ b/templates/default/entity/IdnoPlugins/Reactions/Like/edit.tpl.php
@@ -77,6 +77,21 @@ if ($type == 'like') {
      if ($("#description").val() == '') {
          $('#description-container').hide();
      }
+     if ($("#target").val() != '') {
+         var url = $("#target").val(); 
+         if (url != '') {
+             $('#description-spinner').show();
+
+             var endpoint = "<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>reactions/fetch";
+             $.get(endpoint, {"url": url}, function success(result) {
+                 $('#description').val(result.description || '');
+                 $('#<?= $body_id ?>').val(result.content || '');
+                 $('#description-spinner').hide();
+                 $('#description-container').show();
+             });
+         }
+      }
+
      $('#target').change(function () {
          var url = $(this).val();
          if (url != '') {


### PR DESCRIPTION
$('#target').change() doesn't trigger when val() is provided by script. 
If $target is not empty at page load, fetching page title.
That said, the bookmarklet already does provide the share_title, why not getting this and populate the description field with it, this would probably be more effective...?